### PR TITLE
Handle midnight in is_on and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Times of the Day
+
+A Home Assistant helper integration that exposes binary sensors indicating whether the current time falls within a specified range. Each sensor is defined by two boundaries, **after** and **before**, which can be a clock time or sun event (sunrise/sunset) with optional offsets.
+
+## Features
+- Supports both YAML and GUI configuration
+- Boundaries can use fixed times or sun events
+- Offsets allow adjusting triggers relative to sunrise or sunset
+
+## Development
+This repository contains the core of the integration. To test changes in a Home Assistant environment, copy the `tod` directory to your `custom_components` folder in Home Assistant.
+
+## License
+MIT

--- a/tod/binary_sensor.py
+++ b/tod/binary_sensor.py
@@ -216,9 +216,10 @@ class TodSensor(BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return True if sensor is on."""
+        now = dt_util.utcnow()
         if self._time_after < self._time_before:
-            return self._time_after <= dt_util.utcnow() < self._time_before
-        return False
+            return self._time_after <= now < self._time_before
+        return now >= self._time_after or now < self._time_before
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- fix `is_on` to handle timespans that cross midnight
- document the integration in a new README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af68dcb530832d9a09591bdf3965e1